### PR TITLE
Fix jQuery load usage

### DIFF
--- a/assets/js/custom.js
+++ b/assets/js/custom.js
@@ -1,8 +1,8 @@
 jQuery(document).ready(function($){
-"use scrict";
+"use strict";
     
     // Preloader
-    $(window).load(function(){
+    $(window).on('load', function(){
         setTimeout(function () {
             $('.ta-preloader').fadeOut();
         }, 300);


### PR DESCRIPTION
## Summary
- fix a typo in custom.js
- replace deprecated `.load()` usage with `.on('load')`

## Testing
- `npm test` *(fails: missing `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_6849db62ae00832faeef08911f0446bc