### PR TITLE
Fix typo: rename subscribe feature

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -11,10 +11,10 @@
 
     /**
      * the_words_single_related_post - 10
-     * the_words_subescribe - 20
+     * the_words_subscribe - 20
      * the_words_instagram - 30
     **/
-    do_action('the_words_footer_content','the_words_subescribe');
+    do_action('the_words_footer_content','the_words_subscribe');
     ?>
 
 	</div><!-- #content -->

--- a/header.php
+++ b/header.php
@@ -74,9 +74,9 @@
 			the_words_featured_category();
 
 			/**
-		     * the_words_subescribe - 10
+		     * the_words_subscribe - 10
 		    **/
-		    do_action('the_words_header_content','the_words_subescribe');
+		    do_action('the_words_header_content','the_words_subscribe');
 		}
 
 		?>

--- a/inc/custom-function.php
+++ b/inc/custom-function.php
@@ -590,9 +590,9 @@ endif;
 
 add_action('the_words_footer_content','the_words_single_related_post',10);
 
-if( !function_exists('the_words_subescribe') ):
+if( !function_exists('the_words_subscribe') ):
 
-	function the_words_subescribe(){
+	function the_words_subscribe(){
 
 		if( !is_front_page() ){
 			return;
@@ -604,18 +604,18 @@ if( !function_exists('the_words_subescribe') ):
 		$subscribe_form_shortcode = get_theme_mod('subscribe_form_shortcode');
 		if( $ed_subscribe_section && $subscribe_form_shortcode ){ ?>
 
-		    <div class="ta-subescribe-section">
+		    <div class="ta-subscribe-section">
 		        <div class="ta-container">
 		                
 		                <?php if( $subscribe_form_title || $subscribe_form_description ){ ?>
 
-			                <div class="subescribe-section-title">
+			                <div class="subscribe-section-title">
 
 			                	<?php if( $subscribe_form_title ){ ?>
 
-			                		<div class="subescribe-title-wrap">
+			                		<div class="subscribe-title-wrap">
 
-			                			<span class="subescribe-title-icon">
+			                			<span class="subscribe-title-icon">
 						                	<svg viewBox="0 0 256 512" class="svg-inline--fa fa-chevron-right fa-w-8 fa-3x"><path fill="currentColor" d="M464 64H48C21.5 64 0 85.5 0 112v288c0 26.5 21.5 48 48 48h416c26.5 0 48-21.5 48-48V112c0-26.5-21.5-48-48-48zM48 96h416c8.8 0 16 7.2 16 16v41.4c-21.9 18.5-53.2 44-150.6 121.3-16.9 13.4-50.2 45.7-73.4 45.3-23.2.4-56.6-31.9-73.4-45.3C85.2 197.4 53.9 171.9 32 153.4V112c0-8.8 7.2-16 16-16zm416 320H48c-8.8 0-16-7.2-16-16V195c22.8 18.7 58.8 47.6 130.7 104.7 20.5 16.4 56.7 52.5 93.3 52.3 36.4.3 72.3-35.5 93.3-52.3 71.9-57.1 107.9-86 130.7-104.7v205c0 8.8-7.2 16-16 16z" class=""></path></svg>
 						                </span>
 						                
@@ -648,11 +648,11 @@ endif;
 $ed_subscribe_section_at_top = get_theme_mod('ed_subscribe_section_at_top');
 
 if( !$ed_subscribe_section_at_top ){
-	add_action('the_words_footer_content','the_words_subescribe',20);
+	add_action('the_words_footer_content','the_words_subscribe',20);
 }
 
 if( $ed_subscribe_section_at_top ){
-	add_action('the_words_header_content','the_words_subescribe',20);
+	add_action('the_words_header_content','the_words_subscribe',20);
 }
 
 if( !function_exists('the_words_instagram') ):

--- a/inc/customizer/customizer.php
+++ b/inc/customizer/customizer.php
@@ -83,7 +83,7 @@ function the_words_customize_register( $wp_customize ) {
 	require get_template_directory() . '/inc/customizer/footer.php';
 	require get_template_directory() . '/inc/customizer/layout.php';
 	require get_template_directory() . '/inc/customizer/front-page.php';
-	require get_template_directory() . '/inc/customizer/subescribe.php';
+	require get_template_directory() . '/inc/customizer/subscribe.php';
 	require get_template_directory() . '/inc/customizer/instagram.php';
 	
 	/**  The BLIP Pro Link **/

--- a/inc/customizer/instagram.php
+++ b/inc/customizer/instagram.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * The BLIP Subescribe
+ * The BLIP Subscribe
  *
  * @package The_Words
  */

--- a/inc/customizer/subscribe.php
+++ b/inc/customizer/subscribe.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * The BLIP Subescribe
+ * The BLIP Subscribe
  *
  * @package The_Words
  */

--- a/languages/the-words.pot
+++ b/languages/the-words.pot
@@ -195,7 +195,7 @@ msgstr ""
 msgid "Enable Search"
 msgstr ""
 
-#: inc/customizer/subescribe.php:25
+#: inc/customizer/subscribe.php:25
 msgid "Enable Subscribe Section"
 msgstr ""
 
@@ -336,7 +336,7 @@ msgstr ""
 msgid "Instagram Shortcode"
 msgstr ""
 
-#: inc/custom-function.php:582 inc/customizer/subescribe.php:48
+#: inc/custom-function.php:582 inc/customizer/subscribe.php:48
 msgid ""
 "It has roots in a piece of classical Latin literature from 45 BC, making it "
 "over 2000 years old."
@@ -465,7 +465,7 @@ msgstr ""
 msgid "Pinterest"
 msgstr ""
 
-#: inc/customizer/subescribe.php:71
+#: inc/customizer/subscribe.php:71
 msgid ""
 "Please install \"MC4WP: Mailchimp for WordPress\" plugin for mailchimp form."
 msgstr ""
@@ -542,7 +542,7 @@ msgstr ""
 msgid "Search results for: %s"
 msgstr ""
 
-#: inc/customizer/subescribe.php:86
+#: inc/customizer/subscribe.php:86
 msgid "Show at Top"
 msgstr ""
 
@@ -580,23 +580,23 @@ msgid ""
 "different keywords."
 msgstr ""
 
-#: inc/customizer/subescribe.php:70
+#: inc/customizer/subscribe.php:70
 msgid "Subscribe Form Shortcode"
 msgstr ""
 
-#: inc/customizer/subescribe.php:10
+#: inc/customizer/subscribe.php:10
 msgid "Subscribe Section"
 msgstr ""
 
-#: inc/customizer/subescribe.php:55
+#: inc/customizer/subscribe.php:55
 msgid "Subscribe Section Description"
 msgstr ""
 
-#: inc/customizer/subescribe.php:40
+#: inc/customizer/subscribe.php:40
 msgid "Subscribe Section Title"
 msgstr ""
 
-#: inc/custom-function.php:581 inc/customizer/subescribe.php:33
+#: inc/custom-function.php:581 inc/customizer/subscribe.php:33
 msgid "Subscribe Us For Latest News"
 msgstr ""
 
@@ -663,7 +663,7 @@ msgstr ""
 msgid "This option will work for single posts author box."
 msgstr ""
 
-#: inc/customizer/subescribe.php:87
+#: inc/customizer/subscribe.php:87
 msgid "This section will be display on the footer on default setting."
 msgstr ""
 

--- a/style.css
+++ b/style.css
@@ -2332,40 +2332,40 @@ a.sidebar-cat-item span {
     border: solid 1px white;
     border-radius: 100%;
 }
-.ta-subescribe-section {
+.ta-subscribe-section {
     background: white;
     padding: 50px 0;
     margin-top: 40px;
 }
-.subescribe-section-title {
+.subscribe-section-title {
     text-align: center;
     padding-bottom: 40px;
     width: 50%;
     margin: 0 auto;
 }
-.subescribe-section-title h2, .subescribe-section-title p {
+.subscribe-section-title h2, .subscribe-section-title p {
     margin: 0;
 }
-.subescribe-section-title h2 {
+.subscribe-section-title h2 {
     font-size: 30px;
     position: relative;
 }
-.subescribe-section-title p {
+.subscribe-section-title p {
     padding-top: 10px;
 }
-.subescribe-title-wrap {
+.subscribe-title-wrap {
     display: inline-block;
     position: relative;
 }
-.subescribe-title-wrap h2 {
+.subscribe-title-wrap h2 {
     color: #5ca595;
 }
-span.subescribe-title-icon {
+span.subscribe-title-icon {
     position: absolute;
     right: 0px;
     top: -20px;
 }
-span.subescribe-title-icon svg {
+span.subscribe-title-icon svg {
     color: #f3f3f3;
     font-size: 70px;
     transform: rotate(20deg);
@@ -2373,7 +2373,7 @@ span.subescribe-title-icon svg {
 .ta-mailchimp-form input[type="checkbox"] {
     margin-right: 10px;
 }
-.ta-subescribe-section {
+.ta-subscribe-section {
     background: white;
     padding: 50px 0;
 }
@@ -2643,7 +2643,7 @@ span.subescribe-title-icon svg {
 
 @media(max-width:768px) {
 
-	.mc4wp-form-fields, .subescribe-section-title {
+	.mc4wp-form-fields, .subscribe-section-title {
 	    width: 70%;
 	}
 	.ta-archive-simple .entry-content-wrap {
@@ -2746,7 +2746,7 @@ span.subescribe-title-icon svg {
 		display: none;
 	}
 
-	.mc4wp-form-fields, .subescribe-section-title {
+	.mc4wp-form-fields, .subscribe-section-title {
 	    width: 100%;
 	}
 


### PR DESCRIPTION
## Summary
- rename `subescribe.php` to `subscribe.php`
- update hooks, functions and CSS classes from `subescribe` to `subscribe`
- adjust translation template references

## Testing
- `php -l footer.php`
- `php -l header.php`
- `php -l inc/custom-function.php`
- `php -l inc/customizer/customizer.php`
- `php -l inc/customizer/instagram.php`
- `php -l inc/customizer/subscribe.php`


------
https://chatgpt.com/codex/tasks/task_e_6849e7b684d8832f96e9669c5632fccc