### PR TITLE
Fix echo escaping for widget fields

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -56,7 +56,7 @@
                 for ($x = 0; $x <= 3; $x++) {
                     if( is_active_sidebar('the-words-footer-'.$x) ){
 
-                        echo '<div id="ta-footer-widget-'.$x.'" class="ta-footer-widget glass-card">';
+                        echo '<div id="ta-footer-widget-' . esc_attr( $x ) . '" class="ta-footer-widget glass-card">';
                             dynamic_sidebar('the-words-footer-'.$x);
                         echo '</div>';
 

--- a/inc/custom-function.php
+++ b/inc/custom-function.php
@@ -416,7 +416,7 @@ if( !function_exists('the_words_post_formate') ):
 	    ?>
 	        <div class="post-formate-icon">
 
-	            	<?php echo $icon_class; ?>
+                        <?php echo wp_kses_post( $icon_class ); ?>
 
 	        </div>
 	    <?php

--- a/inc/widgets/widget-fields.php
+++ b/inc/widgets/widget-fields.php
@@ -124,7 +124,7 @@ function the_words_widgets_show_widget_field( $instance = '', $widget_field = ''
             $id = esc_attr($instance->get_field_id($the_words_widgets_name));
             $class = '';
             $int = '';
-            $value = esc_html($athm_field_value);
+            $value = esc_html( $athm_field_value );
             $name = esc_attr($instance->get_field_name($the_words_widgets_name));
 
 
@@ -137,7 +137,7 @@ function the_words_widgets_show_widget_field( $instance = '', $widget_field = ''
 				$output .= '<br />';
 				$output .=  '<small>'. esc_html($the_words_widgets_description).'</small>';
             }
-            $output .= '<input id="' . $id . '" class="upload' . $class . '" type="text" name="' . $name . '" value="' . $value . '" placeholder="' . esc_html__('No file chosen', 'the-words') . '" />' . "\n";
+            $output .= '<input id="' . $id . '" class="upload' . $class . '" type="text" name="' . $name . '" value="' . esc_attr( $value ) . '" placeholder="' . esc_html__( 'No file chosen', 'the-words' ) . '" />' . "\n";
             if (function_exists('wp_enqueue_media')) {
                 
 				$output .= '<input id="upload-' . $id . '" class="upload-button button" type="button" value="' . esc_html__('Upload', 'the-words') . '" />' . "\n";
@@ -167,11 +167,11 @@ function the_words_widgets_show_widget_field( $instance = '', $widget_field = ''
 
                     // Standard generic output if it's not an image.
                     $title = esc_html__('View File', 'the-words');
-                    $output .= '<div class="no-image"><span class="file_link"><a href="' . $value . '" target="_blank" rel="external">' . $title . '</a></span></div>';
+                    $output .= '<div class="no-image"><span class="file_link"><a href="' . esc_url( $value ) . '" target="_blank" rel="external">' . esc_html( $title ) . '</a></span></div>';
                 }
             }
             $output .= '</div></div>' . "\n";
-            echo $output;
+            echo wp_kses_post( $output );
             break;
         
 	}


### PR DESCRIPTION
## Summary
- escape footer widget ids
- sanitize widget upload field output
- sanitize post format icon output

## Testing
- `php -l inc/widgets/widget-fields.php`
- `php -l inc/custom-function.php`
- `php -l footer.php`

------
https://chatgpt.com/codex/tasks/task_e_6849e7cfda00832f9cb807ba73fabd78