### PR TITLE
Restore widgets PHP files

### DIFF
--- a/inc/widgets/author.php
+++ b/inc/widgets/author.php
@@ -1,4 +1,7 @@
- * @package The_BLIP
+<?php
+/**
+ */
+
                 'The_Words_Author_Widget', esc_html__('TA : Author Box', 'the-blip'), array(
                 'description' => esc_html__('This Widget show Author Profile', 'the-blip')
                 'the_words_widgets_title' => esc_html__('Author Name', 'the-blip'),
@@ -7,6 +10,7 @@
                 'the_words_widgets_title' => esc_html__('Facebook Link', 'the-blip'),
                 'the_words_widgets_title' => esc_html__('Twitter Link', 'the-blip'),
                 'the_words_widgets_title' => esc_html__('Youtube Link', 'the-blip'),
+                'the_words_widgets_title' => esc_html__('Instagram Link', 'the-blip'),
                 'the_words_widgets_title' => esc_html__('Instagram Link', 'the-blip'),
 add_action('widgets_init', 'the_words_author_register');
 

--- a/inc/widgets/category.php
+++ b/inc/widgets/category.php
@@ -1,4 +1,8 @@
- * @package The BLIP!
+<?php
+/**
+ * @package The_BLIP
+ */
+
                 'The_Words_Category_Widget', esc_html__('TA : Sidebar Category', 'the-blip'), array(
                 'description' => esc_html__('This Widget show Categories', 'the-blip')
                 'the_words_widgets_title' => esc_html__('Title', 'the-blip'),
@@ -8,6 +12,7 @@
                 'the_words_widgets_title' => esc_html__('Category Four', 'the-blip'),
                 'the_words_widgets_title' => esc_html__('Category Five', 'the-blip'),
                 'the_words_widgets_title' => esc_html__('Category Six', 'the-blip'),
+
 add_action('widgets_init', 'the_words_category_register');
 
 function the_words_category_register() {

--- a/inc/widgets/recent-news.php
+++ b/inc/widgets/recent-news.php
@@ -1,4 +1,7 @@
- * @package The BLIP!
+<?php
+/**
+ * @package The_BLIP
+ */
 				'The_Words_Recent_Posts_Widget', esc_html__('TA : Sidebar Recent Posts', 'the-blip'), array(
 				'description' => esc_html__('This Widget show Recent Posts', 'the-blip')
 					'the_words_widgets_title' => esc_html__('Title', 'the-blip'),

--- a/inc/widgets/widget-fields.php
+++ b/inc/widgets/widget-fields.php
@@ -1,10 +1,11 @@
+<?php
+/**
  * @package The_BLIP
         'label' => esc_html__('--choose--','the-blip')
             echo '<div class="the-blip-multiple-checkbox">'; ?>
-
- * Define fields for Widgets.
- * 
- * @package The_Words
+                    <input id="<?php echo esc_attr( $instance->get_field_id( $the_words_widgets_name ) ); ?>" name="<?php echo esc_attr($instance->get_field_name( $the_words_widgets_name )); ?>" type="checkbox" value="1" <?php checked('1', esc_attr($athm_field_value) ); ?>/>
+                    <label for="<?php echo esc_attr($instance->get_field_id( $the_words_widgets_name )); ?>"><?php echo esc_html($the_words_widgets_title); ?>:</label>
+                </p>
  */
 
 function the_words_widgets_show_widget_field( $instance = '', $widget_field = '', $athm_field_value = '' ) {
@@ -58,9 +59,12 @@ function the_words_widgets_show_widget_field( $instance = '', $widget_field = ''
                     
                 <p>
             $output .= '<input id="' . $id . '" class="upload' . $class . '" type="text" name="' . $name . '" value="' . $value . '" placeholder="' . esc_html__('No file chosen', 'the-blip') . '" />' . "\n";
+            $output .= '<input id="' . $id . '" class="upload' . $class . '" type="text" name="' . $name . '" value="' . $value . '" placeholder="' . esc_html__('No file chosen', 'the-blip') . '" />' . "\n";
 				$output .= '<input id="upload-' . $id . '" class="upload-button button" type="button" value="' . esc_html__('Upload', 'the-blip') . '" />' . "\n";
                 $output .= '<p><i>' . esc_html__('Upgrade your version of WordPress for full media support.', 'the-blip') . '</i></p>';
                 $remove = '<a class="remove-image remove-screenshot">'.esc_html__('Remove','the-blip').'</a>';
+                    $title = esc_html__('View File', 'the-blip');
+
                     $title = esc_html__('View File', 'the-blip');
 
                 <?php

--- a/inc/widgets/widgets.php
+++ b/inc/widgets/widgets.php
@@ -1,5 +1,8 @@
- * The BLIP! Widgets
- * @package The_BLIP
+<?php
+/**
+ *
+ */
+
 		'name'          => esc_html__( 'Sidebar', 'the-blip' ),
 		'description'   => esc_html__( 'Add widgets here.', 'the-blip' ),
 		'name'          => esc_html__( 'Footer One', 'the-blip' ),
@@ -10,6 +13,8 @@
 		'description'   => esc_html__( 'Add widgets here.', 'the-blip' ),
 		'name'          => esc_html__( 'Footer Three', 'the-blip' ),
 		'id'            => 'the-blip-footer-3',
+		'description'   => esc_html__( 'Add widgets here.', 'the-blip' ),
+
 		'description'   => esc_html__( 'Add widgets here.', 'the-blip' ),
 
 /**


### PR DESCRIPTION
## Summary
- restore widget PHP files to valid syntax
- update translation domain to `the-blip`

## Testing
- `php -l inc/widgets/widgets.php`
- `php -l inc/widgets/author.php`
- `php -l inc/widgets/category.php`
- `php -l inc/widgets/recent-news.php`
- `php -l inc/widgets/widget-fields.php`
- `php -l functions.php`


------
https://chatgpt.com/codex/tasks/task_e_684a041f116c832fb17197cb69892b3a